### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,20 +6,20 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-RcPpm                   KEYWORD1
+RcPpm	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-attachInterrupt         KEYWORD2
-detachInterrupt         KEYWORD2
-risingEdgeDetected      KEYWORD2
+attachInterrupt	KEYWORD2
+detachInterrupt	KEYWORD2
+risingEdgeDetected	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-EXTERNAL_INT_NUM        LITERAL1
-MAX_PULSE_NUM           LITERAL1
-PPM_FILTER_WINDOW       LITERAL1
+EXTERNAL_INT_NUM	LITERAL1
+MAX_PULSE_NUM	LITERAL1
+PPM_FILTER_WINDOW	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords